### PR TITLE
Add tests for ArtifactClient

### DIFF
--- a/packages/sdk-artifact/package.json
+++ b/packages/sdk-artifact/package.json
@@ -27,5 +27,8 @@
     "mime-types": "^2.1.35",
     "node-fetch": "^3.2.5",
     "url-join": "^5.0.0"
+  },
+  "devDependencies": {
+    "tmp-promise": "^3.0.3"
   }
 }

--- a/packages/sdk-artifact/src/ArtifactClient.test.ts
+++ b/packages/sdk-artifact/src/ArtifactClient.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'earljs'
+import { ReadStream } from 'fs'
+import { readFile, rm, writeFile } from 'fs/promises'
+import { Readable } from 'stream'
+
+import { mock } from './__test/mock'
+import { ArtifactClient } from './ArtifactClient'
+import { ArtifactApi } from './networking/ArtifactApi'
+import { HttpClient } from './networking/HttpClient'
+
+describe(ArtifactClient.name, () => {
+  const fileFath = 'file.json'
+  const value = { foo: 'bar' }
+  const fileContent = JSON.stringify(value)
+  const key = 'artifact-key'
+
+  it('uploadFile', async () => {
+    await writeFile(fileFath, fileContent)
+    const mockArtifactsApi = mock<ArtifactApi>({
+      uploadArtifact: async () => undefined,
+    })
+    const artifactClient = new ArtifactClient(mockArtifactsApi)
+
+    await artifactClient.uploadFile(key, fileFath)
+
+    expect(mockArtifactsApi.uploadArtifact).toHaveBeenCalledExactlyWith([
+      [expect.a(ReadStream), fileContent.length, key, 'application/json'],
+    ])
+    await rm(fileFath)
+  })
+
+  it('uploadValue', async () => {
+    const mockArtifactsApi = mock<ArtifactApi>({
+      uploadArtifact: async () => undefined,
+    })
+    const artifactClient = new ArtifactClient(mockArtifactsApi)
+
+    await artifactClient.uploadValue(key, value)
+
+    expect(mockArtifactsApi.uploadArtifact).toHaveBeenCalledExactlyWith([
+      [expect.a(ReadStream), fileContent.length, key, 'application/json'],
+    ])
+  })
+
+  it('downloadFile', async () => {
+    const mockArtifactsApi = mock<ArtifactApi>({
+      downloadArtifact: async () => Readable.from([fileContent]),
+    })
+    const artifactClient = new ArtifactClient(mockArtifactsApi)
+
+    await artifactClient.downloadFile(key, fileFath)
+
+    const actualFileContent = await readFile(fileFath)
+    expect(actualFileContent.toString()).toEqual(fileContent)
+    expect(mockArtifactsApi.downloadArtifact).toHaveBeenCalledExactlyWith([[key]])
+    await rm(fileFath)
+  })
+
+  it('uploadValue', async () => {
+    const mockArtifactsApi = mock<ArtifactApi>({
+      downloadArtifact: async () => Readable.from([fileContent]),
+    })
+    const artifactClient = new ArtifactClient(mockArtifactsApi)
+
+    const actualValue = await artifactClient.downloadValue(key)
+
+    expect(actualValue).toEqual(value)
+    expect(mockArtifactsApi.downloadArtifact).toHaveBeenCalledExactlyWith([[key]])
+  })
+
+  it('getArtifactUrl', async () => {
+    const apiRoot = 'https://localhost:0'
+    const mockHttpClient = mock<HttpClient>({})
+    const repoFullName = 'user1/repo1'
+    const artifactApi = new ArtifactApi(mockHttpClient, apiRoot, '', repoFullName)
+    const artifactClient = new ArtifactClient(artifactApi)
+
+    const actualArtifactUrl = artifactClient.getArtifactUrl(key)
+
+    expect(actualArtifactUrl).toEqual('https://localhost:0/artifact/file/user1/repo1/artifact-key')
+  })
+})

--- a/packages/sdk-artifact/src/ArtifactClient.test.ts
+++ b/packages/sdk-artifact/src/ArtifactClient.test.ts
@@ -8,13 +8,15 @@ import { ArtifactClient } from './ArtifactClient'
 import { ArtifactApi } from './networking/ArtifactApi'
 import { HttpClient } from './networking/HttpClient'
 
+const p = ArtifactClient.prototype
+
 describe(ArtifactClient.name, () => {
   const fileFath = 'file.json'
   const value = { foo: 'bar' }
   const fileContent = JSON.stringify(value)
   const key = 'artifact-key'
 
-  it('uploadFile', async () => {
+  it(p.uploadFile.name, async () => {
     await writeFile(fileFath, fileContent)
     const mockArtifactsApi = mock<ArtifactApi>({
       uploadArtifact: async () => undefined,
@@ -29,7 +31,7 @@ describe(ArtifactClient.name, () => {
     await rm(fileFath)
   })
 
-  it('uploadValue', async () => {
+  it(p.uploadValue.name, async () => {
     const mockArtifactsApi = mock<ArtifactApi>({
       uploadArtifact: async () => undefined,
     })
@@ -42,7 +44,7 @@ describe(ArtifactClient.name, () => {
     ])
   })
 
-  it('downloadFile', async () => {
+  it(p.downloadFile.name, async () => {
     const mockArtifactsApi = mock<ArtifactApi>({
       downloadArtifact: async () => Readable.from([fileContent]),
     })
@@ -56,7 +58,7 @@ describe(ArtifactClient.name, () => {
     await rm(fileFath)
   })
 
-  it('uploadValue', async () => {
+  it(p.downloadValue.name, async () => {
     const mockArtifactsApi = mock<ArtifactApi>({
       downloadArtifact: async () => Readable.from([fileContent]),
     })
@@ -68,7 +70,7 @@ describe(ArtifactClient.name, () => {
     expect(mockArtifactsApi.downloadArtifact).toHaveBeenCalledExactlyWith([[key]])
   })
 
-  it('getArtifactUrl', async () => {
+  it(p.getArtifactUrl.name, async () => {
     const apiRoot = 'https://localhost:0'
     const mockHttpClient = mock<HttpClient>({})
     const repoFullName = 'user1/repo1'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,7 @@ importers:
       got: ^12.1.0
       mime-types: ^2.1.35
       node-fetch: ^3.2.5
+      tmp-promise: ^3.0.3
       url-join: ^5.0.0
     dependencies:
       '@actions/github': 5.0.3
@@ -75,6 +76,8 @@ importers:
       mime-types: 2.1.35
       node-fetch: 3.2.5
       url-join: 5.0.0
+    devDependencies:
+      tmp-promise: 3.0.3
 
   packages/sdk-comment:
     specifiers:
@@ -3591,6 +3594,19 @@ packages:
 
   /text-table/0.2.0:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
+    dev: true
+
+  /tmp-promise/3.0.3:
+    resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
+    dependencies:
+      tmp: 0.2.1
+    dev: true
+
+  /tmp/0.2.1:
+    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
+    engines: {node: '>=8.17.0'}
+    dependencies:
+      rimraf: 3.0.2
     dev: true
 
   /tmpl/1.0.5:


### PR DESCRIPTION
So first I've had an idea of adding a version to artifact keys. Then I've decided to start with tests to later better show the changes. And then I've noticed that we already have a version on the API root, so not sure if we need a second one. Either way, tests won't hurt.